### PR TITLE
Make the link of CorePure64.iso always available.

### DIFF
--- a/LiPE.sh
+++ b/LiPE.sh
@@ -3,7 +3,7 @@
 set -e
 
 BOOTLOCAL="https://raw.githubusercontent.com/U2FsdGVkX1/LiPE/main/bootlocal.sh"
-COREPURE="http://www.tinycorelinux.net/13.x/x86_64/release/CorePure64-13.0.iso"
+COREPURE="http://www.tinycorelinux.net/13.x/x86_64/release/CorePure64-current.iso"
 FILENAME=`basename $COREPURE`
 
 [ $EUID -ne 0 ] && echo "This script must be run as root" && exit 1


### PR DESCRIPTION
Prevent the script failed again in the future.